### PR TITLE
Signup 구현 (  front )

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@ant-design/icons": "^5.3.3",
         "antd": "^4.24.15",
+        "axios": "^1.6.8",
         "immer": "^10.0.4",
         "next": "^13.5.6",
         "next-redux-saga": "^4.1.2",
@@ -887,6 +888,11 @@
       "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-4.2.5.tgz",
       "integrity": "sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg=="
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -909,6 +915,16 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -1045,6 +1061,17 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/compute-scroll-into-view": {
       "version": "1.0.20",
@@ -1240,6 +1267,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/dequal": {
@@ -1924,6 +1959,25 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -1931,6 +1985,19 @@
       "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs.realpath": {
@@ -2777,6 +2844,25 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3189,6 +3275,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/front/package.json
+++ b/front/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@ant-design/icons": "^5.3.3",
     "antd": "^4.24.15",
+    "axios": "^1.6.8",
     "immer": "^10.0.4",
     "next": "^13.5.6",
     "next-redux-saga": "^4.1.2",

--- a/front/pages/signup.js
+++ b/front/pages/signup.js
@@ -1,0 +1,146 @@
+import React, { useState, useCallback, useEffect } from "react";
+import Router from "next/router";
+import styled from "styled-components";
+import { useDispatch, useSelector } from "react-redux";
+import { SIGNUP_REQUEST } from "../reducers/user";
+
+import { Form, Checkbox } from "antd";
+import { useInput } from "../hooks/useInput";
+import AppLayout from "../components/AppLayout/AppLayout";
+import {
+  ButtonStyle,
+  ErrorMessage,
+  InputStyle,
+} from "../components/globalStyle/style";
+
+const Signup = () => {
+  const dispatch = useDispatch();
+  const { signupLoading, signupDone } = useSelector((state) => state.user);
+  const [email, onChangeEmail] = useInput("");
+  const [nickname, onChangeNickname] = useInput("");
+  const [password, onChangePassword] = useInput("");
+
+  const [passwordCheck, setPasswordCheck] = useState("");
+  const [passwordError, setPasswordError] = useState(false);
+  const [term, setTerm] = useState(false);
+  const [termError, setTermError] = useState(false);
+
+  useEffect(() => {
+    if (!signupLoading && signupDone) {
+      alert("회원가입 되셨습니다. 로그인 페이지로 이동합니다");
+      Router.push("/login");
+    }
+  }, [signupLoading, signupDone]);
+
+  const onChangePasswordCheck = useCallback(
+    (e) => {
+      setPasswordCheck(e.target.value);
+      setPasswordError(e.target.value !== password);
+    },
+    [password, passwordCheck]
+  );
+  const onChangeTerm = useCallback(
+    (e) => {
+      setTerm(e.target.checked);
+    },
+    [term]
+  );
+
+  const onSubmitSignup = useCallback(() => {
+    if (!email || !nickname) {
+      alert("빈칸을 채워주세요");
+      return;
+    }
+    if (password !== passwordCheck) return setPasswordError(true);
+    if (!term) return setTermError(true);
+
+    console.log("회원가입", email, nickname, password);
+    dispatch({
+      type: SIGNUP_REQUEST,
+      data: { email, nickname, password },
+    });
+    // dispatch(loginAction(username));
+  }, [email, nickname, password, passwordCheck, term]);
+
+  return (
+    <AppLayout>
+      <h1>Signup</h1>
+      <span>Young's Story에 오신 걸 환영합니다</span>
+      <Form onFinish={onSubmitSignup}>
+        <div>
+          <br />
+          <label htmlFor="nickname">nickname</label>
+          <InputStyle
+            type="text"
+            placeholder="nickname을 입력하세요"
+            name="nickname"
+            value={nickname}
+            onChange={onChangeNickname}
+            required
+          />
+        </div>
+        <div>
+          <br />
+          <label htmlFor="email">email</label>
+          <InputStyle
+            type="email"
+            placeholder="email을 입력하세요"
+            name="email"
+            value={email}
+            onChange={onChangeEmail}
+            required
+          />
+        </div>
+        <div>
+          <br />
+          <label htmlFor="password">password</label>
+          <InputStyle
+            type="password"
+            placeholder="password를 입력하세요"
+            name="password"
+            value={password}
+            onChange={onChangePassword}
+            required
+          />
+        </div>
+        <div>
+          <br />
+          <label htmlFor="passwordCheck">password 확인</label>
+          <InputStyle
+            type="password"
+            placeholder="password를 한번 더 입력하세요"
+            name="passwordCheck"
+            value={passwordCheck}
+            onChange={onChangePasswordCheck}
+            required
+          />
+        </div>
+        {passwordError && (
+          <ErrorMessage>비밀번호가 일치하지 않습니다</ErrorMessage>
+        )}
+
+        <div>
+          <br />
+          <Checkbox name="user-term" value={term} onChange={onChangeTerm}>
+            Young와 프로그래밍 공부 하시겠습니까?
+          </Checkbox>
+          {termError && (
+            <ErrorMessage>이용약관에 동의하셔야 합니다.</ErrorMessage>
+          )}
+        </div>
+
+        <ButtonStyle loading={signupLoading}> 회원가입 하기 </ButtonStyle>
+        <p
+          onClick={() => {
+            Router.push("/login");
+          }}
+          style={{ cursor: "pointer" }}
+        >
+          회원이신가요? 로그인하러 가기
+        </p>
+      </Form>
+    </AppLayout>
+  );
+};
+
+export default Signup;

--- a/front/reducers/user.js
+++ b/front/reducers/user.js
@@ -1,3 +1,5 @@
+import { produce } from "immer";
+
 const dummyUser = {
   id: 1,
   username: "thdud",
@@ -9,44 +11,72 @@ const dummyUser = {
 export const initialState = {
   isLoggedIn: false,
   me: dummyUser,
-  signUpData: {},
-  loginData: {},
+
+  signupLoading: false, // 회원가입 시도중
+  signupDone: false,
+  signupError: null,
+
+  loginLoading: false, // 로그인 시도중
+  loginDone: false,
+  loginError: null,
+
+  logoutLoading: false, // 로그아웃 시도중
+  logoutDone: false,
+  logoutError: null,
 };
 
-// async Action
-
 // Action
+export const SIGNUP_REQUEST = "SIGNUP_REQUEST";
+export const SIGNUP_SUCCESS = "SIGNUP_SUCCESS";
+export const SIGNUP_FAILURE = "SIGNUP_FAILURE";
+
+export const LOGIN_REQUEST = "LOGIN_REQUEST";
+export const LOGIN_SUCCESS = "LOGIN_SUCCESS";
+export const LOGIN_FAILURE = "LOGIN_FAILURE";
+
+export const LOGOUT_REQUEST = "LOGOUT_REQUEST";
+export const LOGOUT_SUCCESS = "LOGOUT_SUCCESS";
+export const LOGOUT_FAILURE = "LOGOUT_FAILURE";
+
 export const loginAction = (data) => {
   return {
-    type: "LOG_IN",
+    type: "LOGIN_REQUEST",
     data: data,
   };
 };
 export const logoutAction = () => {
   return {
-    type: "LOG_OUT",
+    type: "LOGOUT_REQUEST",
   };
 };
 
 // reducer : (이전 상태, 액션) => 다음 상태
 const reducer = (state = initialState, action) => {
-  switch (action.type) {
-    case "LOG_IN":
-      console.log("useraction-", action);
-      return {
-        ...state,
-        isLoggedIn: true,
-        me: dummyUser,
-      };
-    case "LOG_OUT":
-      return {
-        ...state,
-        isLoggedIn: false,
-        me: null,
-      };
-    default:
-      return state;
-  }
+  return produce(state, (draft) => {
+    switch (action.type) {
+      case "SIGNUP_REQUEST": {
+        draft.signupLoading = true;
+        draft.signupDone = false;
+        draft.signupError = null;
+        break;
+      }
+      case "SIGNUP_SUCCESS": {
+        console.log("회원가입 리듀서", action.data);
+        draft.signupLoading = false;
+        draft.signupDone = true;
+        break;
+      }
+      case "SIGNUP_FAILURE": {
+        draft.signupLoading = false;
+        draft.signupDone = false;
+        draft.signupError = action.error;
+        break;
+      }
+
+      default:
+        break;
+    }
+  });
 };
 
 export default reducer;

--- a/front/sagas/index.js
+++ b/front/sagas/index.js
@@ -1,11 +1,12 @@
 import { all, fork } from "redux-saga/effects";
-// // import axios from "axios";
+import axios from "axios";
 
 import postSaga from "./post";
+import userSaga from "./user";
 
-// // axios.defaults.baseURL = "http://localhost:3065";
-// // axios.defaults.withCredentials = true;
+axios.defaults.baseURL = "http://localhost:3065";
+axios.defaults.withCredentials = true;
 
 export default function* rootSaga() {
-  yield all([fork(postSaga)]);
+  yield all([fork(postSaga), fork(userSaga)]);
 }

--- a/front/sagas/user.js
+++ b/front/sagas/user.js
@@ -1,0 +1,43 @@
+import axios from "axios";
+import {
+  all,
+  call,
+  delay,
+  fork,
+  put,
+  takeLatest,
+  throttle,
+} from "redux-saga/effects";
+import {
+  SIGNUP_REQUEST,
+  SIGNUP_SUCCESS,
+  SIGNUP_FAILURE,
+} from "../reducers/user";
+
+function signupAPI(data) {
+  return axios.post("/user/signup", data);
+}
+function* signup(action) {
+  try {
+    console.log("회원가입사가", action);
+    const result = yield call(signupAPI, action.data);
+    // yield delay(1000);
+    yield put({
+      type: SIGNUP_SUCCESS,
+      data: result.data,
+    });
+  } catch (error) {
+    console.error("회원가입 saga실패", error);
+    yield put({
+      type: SIGNUP_FAILURE,
+      error: error.response.data,
+    });
+  }
+}
+function* watchSignup() {
+  yield takeLatest(SIGNUP_REQUEST, signup);
+}
+
+export default function* userSaga() {
+  yield all([fork(watchSignup)]);
+}


### PR DESCRIPTION
#2 

상세내용 첨부  
- v1.에서는 회원가입/로그인은 나만 할 거지만 앞으로 버전 업데이트를 생각했을 때, 미리 만들어둠
- 내 메모장이 아닌, 개발 블로그를 예상중이기 때문에 로그인.회원가입 기능 더 생각해야 함
- signup페이지 생성, 비밀번호 확인 / 약관 동의 Error메세지 추가
- dispatch를 사용해 reducer와 saga로 데이터 전송
- saga에서 backend로 API요청
- axios에서 baseURL과 cookie옵션 미리 설정함